### PR TITLE
Move f-Swatches margin override to + selector

### DIFF
--- a/app/templates/src/assets/fabricator/styles/components/swatch.css
+++ b/app/templates/src/assets/fabricator/styles/components/swatch.css
@@ -1,11 +1,14 @@
 .f-Swatches {
-  margin-top: 0;
   margin-bottom: 0;
   display: flex;
   padding-left: 0;
   list-style: none;
 
   flex-wrap: wrap;
+}
+
+.f-Swatches + .f-Swatches {
+  margin-top: 0;
 }
 
 .f-Swatch {


### PR DESCRIPTION
The previous `margin-top: 0` override was resulting in a lack of whitespace between preceding elements and swatches. This tweak only removes the whitespace for adjacent `.f-Swatches` elements.