### PR TITLE
Fix: Rework default layout to only have one body placeholder

### DIFF
--- a/app/templates/src/views/layouts/default.html
+++ b/app/templates/src/views/layouts/default.html
@@ -19,12 +19,14 @@
     <div class="f-Layout-main f-u-cf">
       {{> f-masthead}}
       <div class="f-u-padSides f-u-padBottom">
+  {{/if}}
+
         {% body %}
+
+  {{#if fabricator}}
       </div>
     </div>
     <script src="{{baseurl}}/assets/fabricator/scripts/fabricator.js"></script>
-  {{else}}
-    {% body %}
   {{/if}}
   <script src="{{baseurl}}/assets/toolkit/scripts/toolkit.js"></script>
 </body>


### PR DESCRIPTION
Closes #4

Oddly, the layout/page wrapping that fabricator-assemble performs seems
to break down when there are multiple instances of `{% body %}` in the
template.