### PR TITLE
Fix: Add webpack presets config (and rename loader) to support Babel 6

### DIFF
--- a/app/templates/gulp.config.js
+++ b/app/templates/gulp.config.js
@@ -38,7 +38,8 @@ let config = {
           loaders: [
             {
               test: /\.js$/,
-              loaders: ['babel-loader']
+              loaders: ['babel'],
+              presets: ['es2015']
             }
           ]
         }


### PR DESCRIPTION
#15 

For Babel 6, we need to include a `presets` item in our webpack config. This change adds that item (and also renames the loader reference).

CC @tylersticka @lyzadanger 